### PR TITLE
fix(deps): patch fast-uri and qs Dependabot advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ overrides:
   copy-webpack-plugin>serialize-javascript: ^7.0.5
   css-minimizer-webpack-plugin>serialize-javascript: ^7.0.5
   sockjs>uuid: ^11.1.1
+  express>qs: ^6.16.0
+  body-parser>qs: ^6.16.0
 
 importers:
 
@@ -142,7 +144,7 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: ^3.10.0
-        version: 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/logger':
         specifier: ^3.10.0
         version: 3.10.2
@@ -197,7 +199,7 @@ importers:
         version: 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-common':
         specifier: ^3.10.2
-        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/tsconfig':
         specifier: ^3.10.2
         version: 3.10.2
@@ -4384,8 +4386,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6750,8 +6752,8 @@ packages:
     resolution: {integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -9793,7 +9795,7 @@ snapshots:
       postcss-preset-env: 10.6.1(postcss@8.5.26)
       terser-webpack-plugin: 5.6.1(@swc/core@1.16.0)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)(webpack@5.109.2(@swc/core@1.16.0))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2))(webpack@5.109.2(@swc/core@1.16.0))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.0)))(webpack@5.109.2(@swc/core@1.16.0))
       webpack: 5.109.2(@swc/core@1.16.0)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)
       webpackbar: 7.0.0(@rspack/core@1.7.12)(webpack@5.109.2(@swc/core@1.16.0))
     optionalDependencies:
@@ -9860,7 +9862,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.7.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/bundler@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.7
       '@docusaurus/babel': 3.10.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9871,7 +9873,7 @@ snapshots:
       babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.109.2)
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.109.2)
-      css-loader: 6.11.0(@rspack/core@1.7.12)(webpack@5.109.2)
+      css-loader: 6.11.0(webpack@5.109.2)
       css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.109.2)
       cssnano: 6.1.2(postcss@8.5.26)
       file-loader: 6.2.0(webpack@5.109.2)
@@ -9885,7 +9887,7 @@ snapshots:
       tslib: 2.8.1
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2))(webpack@5.109.2)
       webpack: 5.109.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)
-      webpackbar: 7.0.0(@rspack/core@1.7.12)(webpack@5.109.2)
+      webpackbar: 7.0.0(webpack@5.109.2)
     optionalDependencies:
       '@docusaurus/faster': 3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
     transitivePeerDependencies:
@@ -10118,10 +10120,10 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/core@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/core@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
       '@docusaurus/babel': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/bundler': 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@rspack/core@1.7.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/bundler': 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.2
       '@docusaurus/mdx-loader': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10142,7 +10144,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.4.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.8(@rspack/core@1.7.12)(webpack@5.109.2)
+      html-webpack-plugin: 5.6.8(webpack@5.109.2)
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
@@ -10312,7 +10314,7 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2))(webpack@5.109.2(@swc/core@1.16.0))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.0)))(webpack@5.109.2(@swc/core@1.16.0))
       vfile: 6.0.3
       webpack: 5.109.2(@swc/core@1.16.0)(postcss@8.5.26)
     transitivePeerDependencies:
@@ -10356,7 +10358,7 @@ snapshots:
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2))(webpack@5.109.2(@swc/core@1.16.0))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.0)))(webpack@5.109.2(@swc/core@1.16.0))
       vfile: 6.0.3
       webpack: 5.109.2(@swc/core@1.16.0)
     transitivePeerDependencies:
@@ -10805,13 +10807,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.2
       '@docusaurus/mdx-loader': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -11362,11 +11364,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@docusaurus/mdx-loader': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(@rspack/core@1.7.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@18.3.31)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@docusaurus/utils': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
@@ -11894,7 +11896,7 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2))(webpack@5.109.2(@swc/core@1.16.0))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.0)))(webpack@5.109.2(@swc/core@1.16.0))
       utility-types: 3.11.0
       webpack: 5.109.2(@swc/core@1.16.0)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)
     transitivePeerDependencies:
@@ -11935,7 +11937,7 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2))(webpack@5.109.2(@swc/core@1.16.0))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.0)))(webpack@5.109.2(@swc/core@1.16.0))
       utility-types: 3.11.0
       webpack: 5.109.2(@swc/core@1.16.0)(postcss@8.5.26)
     transitivePeerDependencies:
@@ -11976,7 +11978,7 @@ snapshots:
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2))(webpack@5.109.2(@swc/core@1.16.0))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.0)))(webpack@5.109.2(@swc/core@1.16.0))
       utility-types: 3.11.0
       webpack: 5.109.2(@swc/core@1.16.0)
     transitivePeerDependencies:
@@ -13741,7 +13743,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -14051,7 +14053,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -14472,7 +14474,7 @@ snapshots:
       '@rspack/core': 1.7.12
       webpack: 5.109.2(postcss@8.5.26)
 
-  css-loader@6.11.0(@rspack/core@1.7.12)(webpack@5.109.2):
+  css-loader@6.11.0(webpack@5.109.2):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.26)
       postcss: 8.5.26
@@ -14483,7 +14485,6 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
-      '@rspack/core': 1.7.12
       webpack: 5.109.2
 
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.109.2(@swc/core@1.16.0)):
@@ -15343,7 +15344,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -15378,7 +15379,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fastq@1.20.1:
     dependencies:
@@ -15967,7 +15968,7 @@ snapshots:
       '@rspack/core': 1.7.12
       webpack: 5.109.2(postcss@8.5.26)
 
-  html-webpack-plugin@5.6.8(@rspack/core@1.7.12)(webpack@5.109.2):
+  html-webpack-plugin@5.6.8(webpack@5.109.2):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -15975,7 +15976,6 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      '@rspack/core': 1.7.12
       webpack: 5.109.2
 
   htmlparser2@6.1.0:
@@ -18513,7 +18513,7 @@ snapshots:
 
   pvutils@1.2.0: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -19762,6 +19762,15 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.0)))(webpack@5.109.2(@swc/core@1.16.0)):
+    dependencies:
+      loader-utils: 2.0.4
+      mime-types: 2.1.35
+      schema-utils: 3.3.0
+      webpack: 5.109.2(@swc/core@1.16.0)
+    optionalDependencies:
+      file-loader: 6.2.0(webpack@5.109.2(@swc/core@1.16.0))
+
   url-loader@4.1.1(file-loader@6.2.0(webpack@5.109.2(postcss@8.5.26)))(webpack@5.109.2(postcss@8.5.26)):
     dependencies:
       loader-utils: 2.0.4
@@ -19770,15 +19779,6 @@ snapshots:
       webpack: 5.109.2(postcss@8.5.26)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.109.2(postcss@8.5.26))
-
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.109.2))(webpack@5.109.2(@swc/core@1.16.0)):
-    dependencies:
-      loader-utils: 2.0.4
-      mime-types: 2.1.35
-      schema-utils: 3.3.0
-      webpack: 5.109.2(@swc/core@1.16.0)
-    optionalDependencies:
-      file-loader: 6.2.0(webpack@5.109.2)
 
   url-loader@4.1.1(file-loader@6.2.0(webpack@5.109.2))(webpack@5.109.2):
     dependencies:
@@ -20334,14 +20334,13 @@ snapshots:
       '@rspack/core': 1.7.12
       webpack: 5.109.2(postcss@8.5.26)
 
-  webpackbar@7.0.0(@rspack/core@1.7.12)(webpack@5.109.2):
+  webpackbar@7.0.0(webpack@5.109.2):
     dependencies:
       ansis: 3.17.0
       consola: 3.4.2
       pretty-time: 1.1.0
       std-env: 3.10.0
     optionalDependencies:
-      '@rspack/core': 1.7.12
       webpack: 5.109.2
 
   websocket-driver@0.7.5:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,9 @@ overrides:
   css-minimizer-webpack-plugin>serialize-javascript: ^7.0.5 # GHSA-5c6j-r48x-rmvq
   # SockJS only uses uuid.v4(), whose API remains compatible in the patched release.
   sockjs>uuid: ^11.1.1 # GHSA-w5hq-g745-h8pq
+  # Dev-server query parsing; express 4 / body-parser 1 pin ~6.15 but 6.16 is API-compatible.
+  express>qs: ^6.16.0 # GHSA-x5fp-wj9c-mxmx
+  body-parser>qs: ^6.16.0 # GHSA-x5fp-wj9c-mxmx
 
 onlyBuiltDependencies:
   - '@parcel/watcher'


### PR DESCRIPTION
## Summary

Resolves 5 of the 7 open [Dependabot alerts](https://github.com/signalwire/docusaurus-plugins/security/dependabot). All affected packages are transitive devDependencies of the Docusaurus website build; neither published package under `packages/` depends on them.

| Alerts | Package | Change |
|---|---|---|
| #169, #170, #172, #173 | fast-uri 3.1.5 → 3.1.7 | Lockfile-only bump. `ajv@8` already allows `^3.0.1`. |
| #171 | qs 6.15.3 → 6.16.0 | Scoped overrides `express>qs` and `body-parser>qs` in `pnpm-workspace.yaml`. `express@4.22.2` and `body-parser@1.20.6` pin `~6.15.1`; `body-parser@1.20.8` already moved to `~6.16.0` upstream, so 6.16 is API-compatible. |

### Not fixed: image-size (#167, #168)

No patched release exists. The advisories cover every version through 2.0.2, which is the latest on npm, and the upstream fix is an unmerged PR. `@docusaurus/mdx-loader@3.10.2` (current latest) requires `^2.0.2`. Exposure is low: the parser only runs at build time on images referenced from this repo's own markdown. These alerts should be dismissed as "no fix available" until image-size ships a release.

## Verification

- `pnpm install --frozen-lockfile` succeeds
- `pnpm run build:packages` succeeds
- `pnpm run test:ci`: 7 suites, 35 tests pass
- `pnpm run build:website:only` succeeds

The lockfile diff contains only the two version changes plus peer-suffix key renames from pnpm re-normalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)